### PR TITLE
Ignore params of type ILogger

### DIFF
--- a/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
+++ b/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
@@ -236,6 +236,7 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
             {
                 if (parameter.ParameterType == typeof(HttpRequestMessage)) continue;
                 if (parameter.ParameterType == typeof(TraceWriter)) continue;
+                if (parameter.ParameterType == typeof(Microsoft.Extensions.Logging.ILogger)) continue;
 
                 bool hasUriAttribute = parameter.GetCustomAttributes().Any(attr => attr is FromUriAttribute);
 


### PR DESCRIPTION
The Azure docs recommend ILogger for better logging. Added that to the types that are ignored when creating the definitions in the OpenAPI document.