### PR TITLE
Swagger generation for Azure Function 2.x and .NET Core

### DIFF
--- a/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
+++ b/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
@@ -10,19 +10,21 @@ using System.Net.Http.Formatting;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Web.Http;
-using System.Web.Http.Description;
+using Microsoft.AspNetCore.Http;
+//using System.Web.Http.Description;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host;
 
-namespace mAdcOW.AzureFunction.SwaggerDefinition
+namespace JFDI.SWWaterBitApi.Functions.Functions
 {
     public static class Swagger
     {
         const string SwaggerFunctionName = "Swagger";
 
         [FunctionName(SwaggerFunctionName)]
-        [ResponseType(typeof(void))]
+        [ProducesResponseType(200, Type=typeof(void))]
         public static async Task<HttpResponseMessage> RunAsync([HttpTrigger(AuthorizationLevel.Function, "get")]HttpRequestMessage req)
         {
             var assembly = Assembly.GetExecutingAssembly();
@@ -179,11 +181,11 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
             }
             if (returnType == typeof(HttpResponseMessage))
             {
-                var responseTypeAttr = (ResponseTypeAttribute)methodInfo
-                    .GetCustomAttributes(typeof(ResponseTypeAttribute), false).FirstOrDefault();
+                var responseTypeAttr = (ProducesResponseTypeAttribute)methodInfo
+                    .GetCustomAttributes(typeof(ProducesResponseTypeAttribute), false).FirstOrDefault();
                 if (responseTypeAttr != null)
                 {
-                    returnType = responseTypeAttr.ResponseType;
+                    returnType = responseTypeAttr.Type;
                 }
                 else
                 {
@@ -234,7 +236,8 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
             var parameterSignatures = new List<object>();
             foreach (ParameterInfo parameter in methodInfo.GetParameters())
             {
-                if (parameter.ParameterType == typeof(HttpRequestMessage)) continue;
+                if (parameter.ParameterType == typeof(HttpRequest)) continue;
+                if (parameter.ParameterType == typeof(ExecutionContext)) continue;
                 if (parameter.ParameterType == typeof(TraceWriter)) continue;
                 if (parameter.ParameterType == typeof(Microsoft.Extensions.Logging.ILogger)) continue;
 

--- a/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
+++ b/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
@@ -17,7 +17,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host;
 
-namespace JFDI.SWWaterBitApi.Functions.Functions
+namespace mAdcOW.AzureFunction.SwaggerDefinition
 {
     public static class Swagger
     {


### PR DESCRIPTION
I had some issues getting Swagger.cs to work with Azure Function 2.x (beta) with .NET Core. Here are a few changes that help :)
Changed line 29, 184, 185, ReponseType to ProducesResponseType.
Changed line 239 (HttpRequest instead of HttpRequestMessage):
                if (parameter.ParameterType == typeof(HttpRequest)) continue; // solves stack overflow issue