### PR TITLE
Supports both  .NET 4.x and .NET Core/Standard

### DIFF
--- a/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
+++ b/mAdcOW.AzureFunction.SwaggerDefinition/Swagger.cs
@@ -263,7 +263,7 @@ namespace AzureFunctionSwaggerDefinition
                     }
                 }
 
-                AddToExpando(responses, $"{responseCode}", responseDef); //JJ: made responseCode a variable
+                AddToExpando(responses, $"{responseCode}", responseDef);
             }
 
             return responses;
@@ -274,13 +274,12 @@ namespace AzureFunctionSwaggerDefinition
             var parameterSignatures = new List<object>();
             foreach (ParameterInfo parameter in methodInfo.GetParameters())
             {
-#if SWAGGER_NETCLASSIC
                 if (parameter.ParameterType == typeof(HttpRequestMessage)) continue;
-#else
+#if !SWAGGER_NETCLASSIC
                 if (parameter.ParameterType == typeof(HttpRequest)) continue;
 #endif
                 if (parameter.ParameterType == typeof(ExecutionContext)) continue;
-                if (parameter.ParameterType == typeof(TraceWriter)) continue; //JJ: added this :)
+                if (parameter.ParameterType == typeof(TraceWriter)) continue;
                 if (parameter.ParameterType == typeof(Microsoft.Extensions.Logging.ILogger)) continue;
 
                 bool hasUriAttribute = parameter.GetCustomAttributes().Any(attr => attr is FromUriAttribute);

--- a/mAdcOW.AzureFunction.SwaggerDefinition/Templates.cs
+++ b/mAdcOW.AzureFunction.SwaggerDefinition/Templates.cs
@@ -1,13 +1,24 @@
+#region Test for .NET vs Standard/Core
+#if (NET2 || NET35 || NET40 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472)
+#define SWAGGER_NETCLASSIC
+#endif
+// TODO: Add to the list of .NET versions above if Microsoft releases > 4.7.2
+#endregion
+
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Threading.Tasks;
 using System.Web.Http;
-using System.Web.Http.Description;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host;
+#if SWAGGER_NETCLASSIC
+using System.Web.Http.Description;
+#else
+using Microsoft.AspNetCore.Mvc;
+#endif
 
 namespace mAdcOW.AzureFunction.SwaggerDefinition
 {
@@ -17,7 +28,11 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
         /// When returning a HttpResponseMessage, annotate the class with ResponseType
         /// </summary>
         [FunctionName("TemplatePost1")]
+#if SWAGGER_NETCLASSIC
         [ResponseType(typeof(BodyClass))]
+#else
+        [ProducesResponseType(typeof(BodyClass), 200)]
+#endif
         [Display(Name = "Test Post", Description = "This is a longer description")]
         public static async Task<HttpResponseMessage> Post1(
             [HttpTrigger(AuthorizationLevel.Function, "post")] BodyClass myinput, TraceWriter log)
@@ -50,7 +65,11 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
         /// It's best practice to return a class as a result to provide context and parameter naming 
         /// </summary>
         [FunctionName("TemplateGet1")]
+#if SWAGGER_NETCLASSIC
         [ResponseType(typeof(Result<bool>))]
+#else
+        [ProducesResponseType(typeof(Result<bool>), 200)]
+#endif
         public static async Task<HttpResponseMessage> Get1(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "TemplateGet1/name/{name}/id/{id}")] string name,
             int id, TraceWriter log)
@@ -61,7 +80,7 @@ namespace mAdcOW.AzureFunction.SwaggerDefinition
             {
                 Content = new ObjectContent<Result<bool>>(new Result<bool>(false), new JsonMediaTypeFormatter())
             });
-        }    
+        }
 
         /// <summary>
         /// If returning the result explicitly, there is no need to annotate with ResponseType


### PR DESCRIPTION
Use [ResponseType(typeof(xxxx)] for .NET 4.x, and [ProducesResponseType(typeof(xxxx), 200)] for .NET Core/Standard.